### PR TITLE
为 Firefox 增加激活工具栏按钮的快捷键

### DIFF
--- a/chromium/manifest.json
+++ b/chromium/manifest.json
@@ -12,7 +12,7 @@
         "storage",
         "<all_urls>"
     ],
-    "default_locale" : "en",
+    "default_locale": "en",
     "background": {
         "scripts": [
             "libs/aria2.js",

--- a/chromium_mv3/manifest.json
+++ b/chromium_mv3/manifest.json
@@ -14,7 +14,7 @@
     "host_permissions": [
         "<all_urls>"
     ],
-    "default_locale" : "en",
+    "default_locale": "en",
     "background": {
         "service_worker": "background.js"
     },

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,51 +1,48 @@
 {
-    "name": "__MSG_extension_name__",
-    "description": "__MSG_extension_description__",
-    "version": "3.19.7",
-    "manifest_version": 2,
-    "permissions": [
-        "contextMenus",
-        "downloads",
-        "webRequest",
-        "webRequestBlocking",
-        "tabs",
-        "cookies",
-        "notifications",
-        "storage",
-        "<all_urls>"
-    ],
-    "default_locale" : "en",
-    "background": {
-        "scripts": [
-            "libs/aria2.js",
-            "libs/tools.js",
-            "common.js",
-            "indicator.js",
-            "background.js"
-        ]
+  "name": "__MSG_extension_name__",
+  "description": "__MSG_extension_description__",
+  "version": "3.19.7",
+  "manifest_version": 2,
+  "permissions": [
+    "contextMenus",
+    "downloads",
+    "webRequest",
+    "webRequestBlocking",
+    "tabs",
+    "cookies",
+    "notifications",
+    "storage",
+    "<all_urls>"
+  ],
+  "default_locale": "en",
+  "background": {
+    "scripts": ["libs/aria2.js", "libs/tools.js", "common.js", "indicator.js", "background.js"]
+  },
+  "browser_action": {
+    "default_icon": {
+      "24": "icons/icon24.png"
     },
-    "browser_action": {
-        "default_icon": {
-            "24": "icons/icon24.png"
-        },
-        "default_popup": "popup/index.html"
-    },
-    "icons": {
-        "128": "icons/icon128.png",
-        "16": "icons/icon16.png",
-        "48": "icons/icon48.png"
-    },
-    "options_ui": {
-        "page": "options/index.html",
-        "open_in_tab": false
-    },
-    "applications": {
-        "gecko": {
-            "id": "firefox@downloadWithAria2"
-        }
-    },
-    "developer": {
-       "name": "jc3213",
-       "url": "https://github.com/jc3213/download_with_aria2"
+    "default_popup": "popup/index.html"
+  },
+  "icons": {
+    "128": "icons/icon128.png",
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png"
+  },
+  "options_ui": {
+    "page": "options/index.html",
+    "open_in_tab": false
+  },
+  "applications": {
+    "gecko": {
+      "id": "firefox@downloadWithAria2"
     }
+  },
+  "developer": {
+    "name": "jc3213",
+    "url": "https://github.com/jc3213/download_with_aria2"
+  },
+  "commands": {
+    "_execute_browser_action": {}
+  }
 }

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,48 +1,54 @@
 {
-  "name": "__MSG_extension_name__",
-  "description": "__MSG_extension_description__",
-  "version": "3.19.7",
-  "manifest_version": 2,
-  "permissions": [
-    "contextMenus",
-    "downloads",
-    "webRequest",
-    "webRequestBlocking",
-    "tabs",
-    "cookies",
-    "notifications",
-    "storage",
-    "<all_urls>"
-  ],
-  "default_locale": "en",
-  "background": {
-    "scripts": ["libs/aria2.js", "libs/tools.js", "common.js", "indicator.js", "background.js"]
-  },
-  "browser_action": {
-    "default_icon": {
-      "24": "icons/icon24.png"
+    "name": "__MSG_extension_name__",
+    "description": "__MSG_extension_description__",
+    "version": "3.19.7",
+    "manifest_version": 2,
+    "permissions": [
+        "contextMenus",
+        "downloads",
+        "webRequest",
+        "webRequestBlocking",
+        "tabs",
+        "cookies",
+        "notifications",
+        "storage",
+        "<all_urls>"
+    ],
+    "default_locale": "en",
+    "background": {
+        "scripts": [
+            "libs/aria2.js",
+            "libs/tools.js",
+            "common.js",
+            "indicator.js",
+            "background.js"
+        ]
     },
-    "default_popup": "popup/index.html"
-  },
-  "icons": {
-    "128": "icons/icon128.png",
-    "16": "icons/icon16.png",
-    "48": "icons/icon48.png"
-  },
-  "options_ui": {
-    "page": "options/index.html",
-    "open_in_tab": false
-  },
-  "applications": {
-    "gecko": {
-      "id": "firefox@downloadWithAria2"
+    "browser_action": {
+        "default_icon": {
+            "24": "icons/icon24.png"
+        },
+        "default_popup": "popup/index.html"
+    },
+    "icons": {
+        "128": "icons/icon128.png",
+        "16": "icons/icon16.png",
+        "48": "icons/icon48.png"
+    },
+    "options_ui": {
+        "page": "options/index.html",
+        "open_in_tab": false
+    },
+    "applications": {
+        "gecko": {
+            "id": "firefox@downloadWithAria2"
+        }
+    },
+    "developer": {
+        "name": "jc3213",
+        "url": "https://github.com/jc3213/download_with_aria2"
+    },
+    "commands": {
+        "_execute_browser_action": {}
     }
-  },
-  "developer": {
-    "name": "jc3213",
-    "url": "https://github.com/jc3213/download_with_aria2"
-  },
-  "commands": {
-    "_execute_browser_action": {}
-  }
 }


### PR DESCRIPTION
Fix [Issue #40](https://github.com/jc3213/download_with_aria2/issues/40).

![图片](https://user-images.githubusercontent.com/68013962/189160224-a7d678ca-aecd-431a-9836-5269938127f5.png)

