### PR TITLE
Fix download count and notification when download finished

### DIFF
--- a/chromium/crossbrowser.js
+++ b/chromium/crossbrowser.js
@@ -354,7 +354,7 @@ function aria2WhenStart(message) {
 function aria2WhenComplete(message) {
     if (aria2Storage['notify_complete']) {
         var title = chrome.i18n.getMessage('download_complete');
-        return getNotification(aria2Complete, message);
+        return getNotification(title, message);
     }
 }
 


### PR DESCRIPTION
The download count and notification has been stuck since [4.10.0.2662](https://github.com/jc3213/download_with_aria2/releases/tag/4.10.0.2662).