### PR TITLE
添加动态路径变量功能 & 实现下载文件分类

### DIFF
--- a/chromium/_locales/en/messages.json
+++ b/chromium/_locales/en/messages.json
@@ -580,5 +580,29 @@
     },
     "tips_aria2_bt_seed": {
         "message": "Set the share time of each BitTorrent download (MIN)"
+    },
+    "options_file_types": {
+        "message": "File Types"
+    },
+    "options_file_types_title": {
+        "message": "File Type Configuration"
+    },
+    "tips_options_file_types": {
+        "message": "Configure file types and their extensions for download path categorization"
+    },
+    "tips_add_file_type": {
+        "message": "Add new file type"
+    },
+    "options_edit_file_type": {
+        "message": "Edit File Type"
+    },
+    "tips_edit_file_type": {
+        "message": "Edit file type"
+    },
+    "options_cancel": {
+        "message": "Cancel"
+    },
+    "tips_options_file_types_default": {
+        "message": "Default file type name when no extension matches"
     }
 }

--- a/chromium/_locales/zh/messages.json
+++ b/chromium/_locales/zh/messages.json
@@ -580,5 +580,29 @@
     },
     "tips_aria2_bt_seed": {
         "message": "设置每个 BT 任务的做种时间 (分)"
+    },
+    "options_file_types": {
+        "message": "文件类型"
+    },
+    "options_file_types_title": {
+        "message": "文件类型配置"
+    },
+    "tips_options_file_types": {
+        "message": "配置文件类型及其扩展名，用于下载路径分类"
+    },
+    "tips_add_file_type": {
+        "message": "添加新文件类型"
+    },
+    "options_edit_file_type": {
+        "message": "编辑文件类型"
+    },
+    "tips_edit_file_type": {
+        "message": "编辑文件类型"
+    },
+    "options_cancel": {
+        "message": "取消"
+    },
+    "tips_options_file_types_default": {
+        "message": "当没有匹配到扩展名时的默认文件类型名称"
     }
 }

--- a/chromium/background.js
+++ b/chromium/background.js
@@ -26,11 +26,25 @@ const systemStorage = {
     'folder_defined': '',
     'folder_enabled': false,
     'folder_firefox': false,
+    'file_types_default': 'other',
     'proxy_server': '',
     'proxy_hosts': [],
     'capture_enabled': false,
     'capture_webrequest': false,
-    'capture_hosts': []
+    'capture_hosts': [],
+    'file_types': {
+        "types": {
+            "image": ["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg", "ico"],
+            "video": ["mp4", "avi", "mkv", "mov", "wmv", "flv", "webm", "m4v"],
+            "audio": ["mp3", "wav", "flac", "aac", "ogg", "wma", "m4a"],
+            "document": ["pdf", "doc", "docx", "txt", "rtf", "odt", "md"],
+            "compressed": ["zip", "rar", "7z", "tar", "gz", "bz2", "xz"],
+            "executable": ["exe", "msi", "dmg", "app", "deb", "rpm"],
+            "code": ["js", "css", "html", "php", "py", "java", "c", "cpp", "h", "cs", "go", "rb", "swift"],
+            "ebook": ["epub", "mobi", "azw", "azw3"],
+            "font": ["ttf", "otf", "woff", "woff2"]
+        }
+    }
 };
 
 if (systemManifest.manifest_version === 3) {
@@ -148,7 +162,7 @@ function downloadHeaders(tabId, url, referer) {
     return result;
 }
 
-function downloadDirectory(filename) {
+function downloadDirectory(filename, url, referer, hostname) {
     let dir = null;
     let out = filename;
     let user = aria2Storage['folder_defined'];
@@ -162,14 +176,62 @@ function downloadDirectory(filename) {
     if (aria2Storage['folder_enabled'] &&
         !(systemFirefox && aria2Storage['folder_firefox']) &&
         user) {
-        dir = user;
+        dir = parseVariables(user, hostname, out);
     }
     return { dir, out };
 }
 
+function parseVariables(path, hostname, filename) {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const hour = String(now.getHours()).padStart(2, '0');
+    const minute = String(now.getMinutes()).padStart(2, '0');
+    const second = String(now.getSeconds()).padStart(2, '0');
+    
+    let domain = hostname;
+    let mainDomain = hostname;
+    if (domain) {
+        const parts = domain.split('.');
+        if (parts.length >= 2) {
+            mainDomain = parts.slice(-2).join('.');
+        }
+    }
+    
+    let fileExt = '';
+    let fileType = aria2Storage['file_types_default'] || 'other';
+    if (filename) {
+        const extIdx = filename.lastIndexOf('.');
+        if (extIdx > 0) {
+            fileExt = filename.substring(extIdx + 1).toLowerCase();
+            const fileTypes = aria2Storage['file_types'] || { types: {} };
+            for (const [type, extensions] of Object.entries(fileTypes.types)) {
+                if (extensions.includes(fileExt)) {
+                    fileType = type;
+                    break;
+                }
+            }
+        }
+    }
+    
+    return path
+        .replace(/\{year\}/g, year)
+        .replace(/\{month\}/g, month)
+        .replace(/\{day\}/g, day)
+        .replace(/\{hour\}/g, hour)
+        .replace(/\{minute\}/g, minute)
+        .replace(/\{second\}/g, second)
+        .replace(/\{domain\}/g, domain || '')
+        .replace(/\{mainDomain\}/g, mainDomain || '')
+        .replace(/\{filename\}/g, filename || '')
+        .replace(/\{fileext\}/g, fileExt || '')
+        .replace(/\{filetype\}/g, fileType);
+}
+
 function downloadHandler(url, referer, filename, hostname, tabId) {
-    let options = downloadDirectory(filename);
     hostname ??= getHostname(referer);
+    let options = downloadDirectory(filename, url, referer, hostname);
     if (matchHostname(proxyHosts, hostname)) {
         options['all-proxy'] = aria2Storage['proxy_server'];
     }

--- a/chromium/pages/options/options.css
+++ b/chromium/pages/options/options.css
@@ -128,3 +128,50 @@ i {
 .disabled::before {
     content: "__MSG_options_disabled__: ";
 }
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 9999;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 500px;
+    border-radius: 5px;
+}
+
+.modal-content input {
+    width: 100%;
+    margin: 10px 0;
+    padding: 5px;
+}
+
+.modal-buttons {
+    margin-top: 20px;
+    text-align: right;
+}
+
+.modal-buttons button {
+    margin-left: 10px;
+    padding: 5px 15px;
+}
+
+.rule button {
+    padding: 0 5px;
+    cursor: pointer;
+}
+
+.rule button:hover {
+    background-color: #f0f0f0;
+}

--- a/chromium/pages/options/options.html
+++ b/chromium/pages/options/options.html
@@ -108,6 +108,26 @@
             <div class="pad-u e-folder-enabled x-folder-firefox" i18n-tips="tips_options_folder">
                 <input name="folder_defined" type="text">
             </div>
+            <h1 i18n="options_file_types"></h1>
+            <div id="file_types" class="flexmenu" i18n-tips="tips_options_file_types">
+                <h4 i18n="options_file_types_title"></h4>
+                <button id="add-file-type" i18n-tips="tips_add_file_type">➕ Add File Type</button>
+                <div class="list"></div>
+            </div>
+            <div id="file-type-modal" class="modal">
+                <div class="modal-content">
+                    <h3 id="modal-title" i18n="options_add_file_type"></h3>
+                    <input type="text" id="file-type-name" placeholder="Type name">
+                    <input type="text" id="file-type-extensions" placeholder="Extensions (comma separated)">
+                    <div class="modal-buttons">
+                        <button id="save-file-type" i18n="options_save"></button>
+                        <button id="cancel-file-type" i18n="options_cancel"></button>
+                    </div>
+                </div>
+            </div>
+            <div class="pad-u" i18n-tips="tips_options_file_types_default">
+                <input name="file_types_default" type="text" placeholder="Default file type name">
+            </div>
             <h1 i18n="options_proxy"></h1>
             <div i18n-tips="tips_options_proxy">
                 <input name="proxy_server" type="text" placeholder="http://127.0.0.1:1280/">

--- a/chromium/pages/options/options.js
+++ b/chromium/pages/options/options.js
@@ -14,6 +14,20 @@ let tellUA = document.getElementById('useragent');
 let storageEntries = storagePane.querySelectorAll('[name]');
 let jsonrpcEntries = jsonrpcPane.querySelectorAll('[name]');
 let matchLET = template.firstElementChild;
+let fileTypeEditor = document.getElementById('file_types');
+let fileTypeNameInput = document.getElementById('file-type-name');
+let fileTypeExtensionsInput = document.getElementById('file-type-extensions');
+let addFileTypeBtn = document.getElementById('add-file-type');
+let fileTypeList = fileTypeEditor.querySelector('.list');
+
+
+let fileTypeModal = document.getElementById('file-type-modal');
+let modalTitle = document.getElementById('modal-title');
+let saveFileTypeBtn = document.getElementById('save-file-type');
+let cancelFileTypeBtn = document.getElementById('cancel-file-type');
+
+let currentFileTypeOperation = null;
+let currentEditType = null;
 
 function changeHistorySave(change) {
     let { id, new_value } = change;
@@ -80,6 +94,11 @@ function changeHistoryLoad(loadList, saveList, loadButton, saveButton, key, todo
     } else if (type === 'resort') {
         let order = todo === 'undo' ? sort.old_order : sort.new_order;
         sort.list.append(...order);
+    } else if (type === 'file_types' && fileTypeList) {
+        fileTypeList.innerHTML = '';
+        for (let [typeName, extensions] of Object.entries(value.types)) {
+            printFileType(fileTypeList, typeName, extensions);
+        }
     } else {
         entry.value = value;
     }
@@ -157,6 +176,34 @@ fileEntry.addEventListener('change', (event) => {
         fileEntry.value = '';
     };
     reader.readAsText(file);
+});
+
+addFileTypeBtn.addEventListener('click', addFileType);
+fileTypeExtensionsInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+        addFileType();
+    }
+});
+
+fileTypeList.addEventListener('click', (event) => {
+    if (event.target.getAttribute('i18n-tips') === 'tips_match_remove') {
+        removeFileType(event);
+    }
+});
+
+saveFileTypeBtn?.addEventListener('click', saveFileType);
+cancelFileTypeBtn?.addEventListener('click', cancelFileType);
+
+window.addEventListener('click', (event) => {
+    if (event.target === fileTypeModal) {
+        cancelFileType();
+    }
+});
+
+window.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && fileTypeModal && fileTypeModal.style.display === 'block') {
+        cancelFileType();
+    }
 });
 
 function optionsDispatch(options) {
@@ -246,6 +293,101 @@ function printMatchPattern(list, id, value) {
     return rule;
 }
 
+function printFileType(list, typeName, extensions) {
+    let rule = matchLET.cloneNode(true);
+    rule.title = typeName;
+    rule.firstElementChild.textContent = `${typeName}: ${extensions.join(', ')}`;
+    let editButton = document.createElement('button');
+    editButton.textContent = '✏️';
+    editButton.setAttribute('i18n-tips', 'tips_edit_file_type');
+    editButton.style.marginRight = '5px';
+    editButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        editFileType(typeName, extensions);
+    });
+    rule.insertBefore(editButton, rule.lastElementChild);
+    list.appendChild(rule);
+    return rule;
+}
+
+function addFileType() {
+    if (!fileTypeModal) {
+        return;
+    }
+    currentFileTypeOperation = 'add';
+    currentEditType = null;
+    modalTitle.textContent = 'Add File Type';
+    fileTypeNameInput.value = '';
+    fileTypeExtensionsInput.value = '';
+    fileTypeModal.style.display = 'block';
+}
+
+function removeFileType(event) {
+    if (!fileTypeList) {
+        return;
+    }
+    let typeName = event.target.parentNode.title;
+    let old_value = changes['file_types'] || { types: {} };
+    let new_value = JSON.parse(JSON.stringify(old_value));
+    delete new_value.types[typeName];
+    fileTypeList.innerHTML = '';
+    for (let [type, exts] of Object.entries(new_value.types)) {
+        printFileType(fileTypeList, type, exts);
+    }
+    changeHistorySave({ id: 'file_types', new_value, old_value, type: 'file_types' });
+}
+
+function editFileType(typeName, extensions) {
+    if (!fileTypeModal) {
+        return;
+    }
+    currentFileTypeOperation = 'edit';
+    currentEditType = typeName;
+    modalTitle.textContent = 'Edit File Type';
+    fileTypeNameInput.value = typeName;
+    fileTypeExtensionsInput.value = extensions.join(', ');
+    fileTypeModal.style.display = 'block';
+}
+
+function saveFileType() {
+    if (!fileTypeList) {
+        return;
+    }
+    let typeName = fileTypeNameInput.value.trim();
+    let extensionsInput = fileTypeExtensionsInput.value.trim();
+    if (!typeName || !extensionsInput) {
+        return;
+    }
+    let extensions = extensionsInput.split(',').map(ext => ext.trim().toLowerCase()).filter(ext => ext);
+    let old_value = changes['file_types'] || { types: {} };
+    let new_value = JSON.parse(JSON.stringify(old_value));
+    
+    if (currentFileTypeOperation === 'edit' && currentEditType) {
+        delete new_value.types[currentEditType];
+        new_value.types[typeName] = extensions;
+    } else if (currentFileTypeOperation === 'add') {
+        new_value.types[typeName] = extensions;
+    }
+    
+    fileTypeList.innerHTML = '';
+    for (let [type, exts] of Object.entries(new_value.types)) {
+        printFileType(fileTypeList, type, exts);
+    }
+    changeHistorySave({ id: 'file_types', new_value, old_value, type: 'file_types' });
+    cancelFileType();
+}
+
+function cancelFileType() {
+    if (!fileTypeModal) {
+        return;
+    }
+    fileTypeModal.style.display = 'none';
+    currentFileTypeOperation = null;
+    currentEditType = null;
+    fileTypeNameInput.value = '';
+    fileTypeExtensionsInput.value = '';
+}
+
 function storageDispatch() {
     changes = { ...aria2Storage };
     tellVer.textContent = aria2Version;
@@ -262,9 +404,19 @@ function storageDispatch() {
         }
     }
     for (let [id,  { list }] of matchLists) {
-        list.innerHTML = '';
-        for (let value of changes[id]) {
-            printMatchPattern(list, id, value);
+        if (list) {
+            list.innerHTML = '';
+            for (let value of changes[id]) {
+                printMatchPattern(list, id, value);
+            }
+        }
+    }
+
+    if (fileTypeList) {
+        fileTypeList.innerHTML = '';
+        let fileTypes = changes['file_types'] || { types: {} };
+        for (let [type, extensions] of Object.entries(fileTypes.types)) {
+            printFileType(fileTypeList, type, extensions);
         }
     }
 }


### PR DESCRIPTION
## 1. 摘要

*   **影响范围：** 🟡 **中等** - 添加了文件分类和动态路径变量功能
*   **核心变更：**
    *    新增文件类型配置系统，9种预定义文件类型（图片、视频、音频、文档等）
    *    增强下载路径变量替换，支持 `{filetype}`、`{domain}`、`{year}` 等动态变量
    *    在选项页面添加完整的文件类型管理UI（增删改查）

---

## 2. 变更

### 📦 组件一：后台逻辑（`chromium/background.js`）

#### 变更内容：
1. **新增配置项**（第29-47行）：
   - `file_types_default`: 默认文件类型名称（默认 `'other'`）
   - `file_types`: 预定义9种文件类型及其扩展名映射

2. **新增 `parseVariables()` 函数**（第184-230行）：
   - 时间变量：`{year}`、`{month}`、`{day}`、`{hour}`、`{minute}`、`{second}`
   - 域名变量：`{domain}`（完整域名）、`{mainDomain}`（主域名）
   - 文件变量：`{filename}`、`{fileext}`（扩展名）、`{filetype}`（文件类型）
   - 文件类型匹配逻辑：遍历 `file_types.types`，根据扩展名查找对应类型


#### 预定义的文件类型表：

| 类型名称 | 扩展名示例 |
|---------|-----------|
| **image** | jpg, jpeg, png, gif, webp, bmp, svg, ico |
| **video** | mp4, avi, mkv, mov, wmv, flv, webm, m4v |
| **audio** | mp3, wav, flac, aac, ogg, wma, m4a |
| **document** | pdf, doc, docx, txt, rtf, odt, md |
| **compressed** | zip, rar, 7z, tar, gz, bz2, xz |
| **executable** | exe, msi, dmg, app, deb, rpm |
| **code** | js, css, html, php, py, java, c, cpp, h, cs, go, rb, swift |
| **ebook** | epub, mobi, azw, azw3 |
| **font** | ttf, otf, woff, woff2 |

---

### 🎨 组件二：用户界面（`chromium/pages/options/`）

#### HTML 变更（`options.html`）：
- **新增文件类型配置区域**（第111-130行）：
  - 标题："文件类型"
  - "➕ Add File Type" 按钮
  - 文件类型列表容器
  - 模态框（Modal）用于添加/编辑文件类型
  - 默认文件类型名称输入框

#### CSS 变更（`options.css`）：
- **新增模态框样式**（第132-177行）：
  - `.modal`: 固定定位、半透明背景
  - `.modal-content`: 居中显示、圆角边框
  - `.modal-buttons`: 按钮容器
  - `.rule button`: 列表项内按钮样式

#### JavaScript 变更（`options.js`）：

**新增核心函数：**

| 函数名 | 功能描述 |
|--------|---------|
| `printFileType()` | 渲染单个文件类型到列表（第296-311行） |
| `addFileType()` | 打开添加文件类型模态框（第313-323行） |
| `removeFileType()` | 删除指定文件类型（第325-338行） |
| `editFileType()` | 打开编辑文件类型模态框（第340-350行） |
| `saveFileType()` | 保存文件类型变更（第352-378行） |
| `cancelFileType()` | 关闭模态框并重置状态（第380-389行） |

**事件监听器：**
- 点击"添加文件类型"按钮 → `addFileType()`
- 输入框按 Enter 键 → `addFileType()`
- 点击列表项删除按钮 → `removeFileType()`
- 点击编辑按钮 → `editFileType()`
- 点击保存/取消按钮 → `saveFileType()` / `cancelFileType()`
- 点击模态框外部或按 Escape 键 → `cancelFileType()`

---


## 3. 影响与风险评估

### ⚠️ 潜在风险：

1. **向后兼容性：**
   - 新增了 `file_types` 和 `file_types_default` 配置项，旧版本扩展升级后需要初始化这些值


2. **性能影响：**
   - `parseVariables()` 在每次下载时都会执行文件类型匹配循环
   - **风险：** 如果用户配置了大量文件类型，可能影响下载启动速度


3. **用户体验：**
   - 模态框没有输入验证（如重复类型名、空扩展名）


### ✅ 测试建议：
#### 仅覆盖个人使用场景，未完成全部边界测试，欢迎一起完善。
1. **功能测试：**
   - [x] 添加新文件类型，验证扩展名匹配是否正确
   - [x] 编辑现有文件类型，验证扩展名更新是否生效
   - [x] 删除文件类型，验证列表更新和撤销功能
   - [x] 测试默认文件类型配置

2. **路径变量测试：**
   - [x] 下载不同类型文件，验证 `{filetype}` 变量是否正确替换
   - [x] 测试 `{domain}` 和 `{mainDomain}` 变量
   - [ ] 测试时间变量 `{year}`、`{month}` 等
   - [x] 测试未匹配扩展名时是否使用默认类型

3. **边界情况：**
   - [x] 文件名无扩展名的情况
   - [ ] 多个扩展名的情况（如 `.tar.gz`）
   - [ ] 大小写混合的扩展名
   - [ ] 空文件类型列表

4. **UI/UX ：**
   - [x] 模态框打开/关闭动画
   - [x] 键盘快捷键（Enter、Escape）
   - [x] 点击模态框外部关闭
   - [x] 撤销/重做文件类型变更

---

## 4. 使用示例
直觉化操作

<img width="1423" height="745" alt="image" src="https://github.com/user-attachments/assets/9139a876-219c-4ced-acfb-28322da636d9" />

